### PR TITLE
Added test-udp-puncher

### DIFF
--- a/udp-echo/test-udp-puncher/README.md
+++ b/udp-echo/test-udp-puncher/README.md
@@ -1,0 +1,192 @@
+## TEST CLIENT AND SERVER FOR UDP HOLE PUNCHER
+
+_The test code is derived the code originally written by Rob Bultman github.com/rbultman for the Raspberry Jam project. Details at https://github.com/rbultman/raspberry-jam. This description was created by Vijay Vaidyanathan github.com/vvaidy and released into the Public Domain, Aug 1 2020._
+
+### WARNINGS
+
+1. This is a simple proof-of-concept hole-puncher, and doesn't try to handle even the simple variations on the basic UDP hole-punching formula.
+2. **SUPER IMPORTANT**. There is a **really good reason** that NAT server and UDP firewalls exist: security. Amongst other things, NAT protects your machine by making it inaccessible to other machins on the internet that might be trying to connect to your machine. This test hole-puncher code effectively denies your software and machine some of those protections. In fact, as implemented, it actually advertises and exposes your machine to external internet connections. So, PLEASE DO NOT DO THIS unless you really understand what you are doing. This code is meant purely for developers trying to understand how their NAT servers work. Please, DO NOT USE THIS CODE AS-IS FOR ANYTHING OTHER THAN LEARNING HOW THIS WORKS! YOU"VE BEEN WARNED, YOU ARE NOW ENTIRELY ON YOUR OWN. THERE ARE NO WARRANTIES OF ANY KIND etc etc etc.
+
+OK, you may now read on :-)
+
+### COMPILE
+
+To compile (I've tested this on Ubuntu 18.04 LTS Bionic and MacOS 10.14.6 Mojave). All you need is a working `g++` (or equivalent).
+
+```
+g++ test-client.cpp -o test-client
+g++ test-server.cpp -o test-server
+```
+
+### RUNNING THE SERVER
+
+Run the test server. Make sure you are on a machine that is directly accessable on the open internet at the port you pick (e.g. by setting up port forwarding on your router or opening up ports on your firewall etc.):
+
+```
+./test-server -p PORT_NUMBER
+```
+
+e.g.
+
+```
+./test-server -p 8080
+```
+
+### RUNNING THE FIRST PEER TEST CLIENT
+
+You need to run (at least) two test clients. They do NOT need to be directly accessable on the open internet, they only need to be able to directly access the internet). In a proper test, each test client should be behind a different firewall/NAT, but it will also work of both clients and the server are behind the same firewall/NAT:
+
+```
+./test-server -s TEST_SERVER_IP_ADDRESS -p TEST_SERVER_PORT_NUMBER -n A_NAME_I_PICK_FOR_MYSELF -c THE_NAME_OF_THE_PEER_I_AM_CONTACTING
+```
+
+To test the server and two clients on your local machine, start the server ...
+
+```
+./test-server -p 8080
+```
+
+Next, start a client called `alice` that wants to connect to a peer client called `bob`
+
+```
+./test-client -s 127.0.0.1 -p 8080 -n alice -c bob
+```
+
+The server should respond within a few seconds (configurable in the server code) with a "Phonebook" of entries for connected clients. If this is the first client to connect you will only see a single entry in the phonebook at this time. See _How it works_ below for more details.
+
+### RUNNING THE SECOND PEER TEST CLIENT
+
+Now start the `bob` peer client and tell it to connect to `alice`
+
+```
+./test-client -s 127.0.0.1 -p 8080 -n bob -c alice
+```
+
+You should get a response shortly with an updated phonebook that includes both the `bob` and `alice` entries. It might take about 10 or 20 seconds before you see the full phonebook (see the code for details). The `alice` peer client will also eventually refresh its request and see the new phonebook that will include bob. As soon as each peer client notices the entry they are trying to contact show up in the phonebook, they start trying to connect the peer client directly.
+
+### How it works on the server
+
+When two peers behind NATs want to connect to each other, there are two different problems that need to be solved. The first is that each peer is not directly addressable on the internet but is connecting through a NAT device of some sort that is assigning some new external address (including a port number) to the client socket. So, the first problem is to figure out what this external address is. The second problem is to signal to other people so they can reach you at this external address. The server handles these two problems through its phonebook.
+
+Technically speaking, problem #1 is easy enough to solve: there are a lot of ways you can discover your own external address ... e.g. STUN or you can even just hit google or some other server that will tell you what _it_ saw as your IP address.
+
+The test server solves problem #2 by requiring that when a peer client connects to the server, the client associates itself with a unique name. The server stores client names and client external addresses in its phonebook, and sends a copy of its phonebook as a response to anyone that connects to it.
+
+The client name is pretty much any string (so make sure you pick a unique name for each test client!). The server phonebook is implemented as a simple static circular buffer, which means that entries are added one at a time as new clients connect. If the name is already in the phonebook, the old address is overwritten. If it's not in the address book, it's added. When MAXCLIENTS number of entries is reached, it just wraps around overwriting the oldest client entries. MAXCLIENTS is configurable in `test-server.cpp`. Each time a client connects to it, it sends back the entire phonebook as a response to that client. That's pretty much the only thing the server does.
+
+_Note: In the code, I refer to the server as the "Stage Manager". The original analogy I was working towards was a piece of software that manages who is "on stage" and that all subscribers to a stage (think of it as a chat room for a digital stream) can receive direct, peer-to-peer streams from the entities "on stage". That analogy didnt quite survive, but the variable names did._
+
+### How it works on each peer client
+
+Each client is behind it's own NAT, and is not directly reachable on the internet. This means that no one "on the outside" can initiate connections to the client. However, machines on the outside of the firewall _can_ send responses to packets that were initiated by the client, and these responses need to be forwarded back to the client. Therefore, the NAT software sets up an exteral IP address and port mapping for server responses, and these response packets are forwarded back to the client's initiating socket. Understanding how these responses are treated and forwarded back to the initiating client socket by the NAT software is crucial to understanding how UDP hole punching works.
+
+Recall that when a client connects to the test server, it gets back the phone book of all other connected clients along with the IP addresses and ports for each client. Assume Alice and Bob are two clients that want to tallk directly to each other. Once Alice and Bob are connected to the test server, they each get a copy of the phonebook, and so can locate each other through each other's external IP addresses and port. However, that can't be used right away to connect to the client because the NAT will drop any packets that aren't a response to a connection initiated from within the NAT to that address.
+
+Here is the crucial trick: both clients initiate connections to each other anyway! Let's assume Alice happens to go first. The first packet from Alice to Bob is in fact dropped by Bob's firewall because Bob hasn't (yet) initiated a connection to Alice. However, Bob's packet to Alice's external IP address and port _is_ sent forwarded back to Alice. Why? Because the NAT sees it as a response to the packet that Alice previously initiated to Bob. Now, when Alice sends her next packet to Bob, Bob's firewall sees it as a response to the packet that Bob had previously sent, and forwards it back to Bob, and you have a direct two-way connection between Alice and Bob, with each NAT thinking that it is sending only responses to packets that were first initiated from within the network.
+
+This all relies on the external address for Alice and Bob in the phone book being accurate. However, recall that those phone entries were set up by the NAT for responses from the Server. This relies on the fact that most NATs preserve the mapping it set up to handle responses from the server for all other responses on the same client socket. Most NATs do, but not all do. Some NATs do switch things around a bit, but in predictable ways, and it's usually easy enough to modify the client to account for some of these patterns. This basic test code should work for most common NATs.
+
+This is a simple, single threaded example, where the main thread waits for incoming packets and artificially sleeps for one second between messages. In reality, we'd want better latency than that, but the basic mechanism to traverse NATs would be largely similar to this example.
+
+### Relationship to STUN, TURN, ICE, WebRTC etc.
+
+There are a number of solutions to the basic problem of connecting across NATs. Pieces of this are solved by STUN, TURN, ICE and browser based support is baked into WebRTC. All of those techniques rely on some form of getting across NATs (without having to configure routers etc), and this code is intended as a simple example to demonstrate how those all work at a UDP level.
+
+### A Sample Run
+
+(I'm assuming the server is running on SSS.SSS.SSS.SSS on port 8080, and bob and alice are trying to connect with each other, and the XX.XX.XX.XX,YYYY represent IP addresses and portnumbers)
+
+On the server:
+
+```
+test-puncher-server$ ./test-server -p 8080
+Connection Server ready to receive on port 8080.
+Make sure this is reachable from the internet.
+Client from XX.XX.XX.XX : YYYY sent: alice
+Adding client #0 to table of clients.
+0,1,alice,XX.XX.XX.XX,YYYY
+Client from XX.XX.XX.XX : YYYY sent: bob
+Adding client #1 to table of clients.
+0,2,alice,XX.XX.XX.XX,YYYY
+1,2,bob,XX.XX.XX.XX,YYYY
+Client from XX.XX.XX.XX : YYYY sent: alice
+Updating client #0 in table of clients.
+0,2,alice,XX.XX.XX.XX,YYYY
+1,2,bob,XX.XX.XX.XX,YYYY
+Client from XX.XX.XX.XX : YYYY sent: bob
+Updating client #1 in table of clients.
+0,2,alice,XX.XX.XX.XX,YYYY
+1,2,bob,XX.XX.XX.XX,YYYY
+Client from XX.XX.XX.XX : YYYY sent: alice
+Updating client #1 in table of clients.
+0,2,alice,XX.XX.XX.XX,YYYY
+1,2,bob,XX.XX.XX.XX,YYYY
+Client from XX.XX.XX.XX : YYYY sent: bob
+Updating client #1 in table of clients.
+0,2,alice,XX.XX.XX.XX,YYYY
+1,2,bob,XX.XX.XX.XX,YYYY
+```
+
+The thing to take away from the transcript above is that alice and bob are registering with the server regularly and receiving updated copies of the phonebook (which has just two entries in this example)
+
+At client #1, Alice:
+
+```
+alice$ ./test-client -s SSS.SSS.SSS.SSS -p 8080 -n alice -c bob
+Stage Manager Server address: SSS.SSS.SSS.SSS
+My Name: alice
+Registering with Stage Manager.
+Retrieving incoming messages
+.Stage Manager sent us a Phonebook entry: 0,1,alice,XX.XX.XX.XX,YYYY
+Peer: 0/1 alice@XX.XX.XX.XX,YYYY
+.............................Registering with Stage Manager.
+Retrieving incoming messages.
+.Stage Manager sent us a Phonebook entry: 0,2,alice,XX.XX.XX.XX,YYYY
+Peer: 0/2 alice@XX.XX.XX.XX,YYYY
+.Stage Manager sent us a Phonebook entry: 1,2,bob,XX.XX.XX.XX,YYYY
+Peer: 1/2 bob@XX.XX.XX.XX,YYYY
+Located bob!
+......................We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from bob to alice
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from bob to alice
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from bob to alice
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from bob to alice
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+^C
+```
+
+At Client #2, Bob:
+
+```
+$ ./test-client -s SSS.SSS.SSS.SSS -p 8080 -n bob -c alice
+Stage Manager Server address: SSS.SSS.SSS.SSS
+My Name: bob
+Registering with Stage Manager.
+Retrieving incoming messages.
+.We received a peer message of len 30 from XX.XX.XX.XX,YYYY ->>
+0,2,alice,XX.XX.XX.XX,YYYY
+
+.Stage Manager sent us a Phonebook entry: 1,2,bob,XX.XX.XX.XX,YYYY
+Peer: 1/2 bob@XX.XX.XX.XX:YYYY
+............................Registering with Stage Manager.
+Retrieving incoming messages.
+.Stage Manager sent us a Phonebook entry: 0,2,alice,XX.XX.XX.XX,YYYY
+Peer: 0/2 alice@XX.XX.XX.XX:YYYY
+Located alice!
+.Stage Manager sent us a Phonebook entry: 1,2,bob,XX.XX.XX.XX,YYYY
+Peer: 1/2 bob@XX.XX.XX.XX:YYYY
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from alice to bob
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from alice to bob
+.We received a peer message of len 46 from XX.XX.XX.XX,YYYY ->>
+This is a direct P2P message from alice to bob
+^C
+```
+
+Notice the spurious message from the server to the client which is detected as a peer message of len 30, but is really a response message from the server with a phonebook entry. It doesn't matter that we didn't catch that properly, since we'll get a proper copy when we re-register with the server soon.
+
+The interesting bit is that the messages that say "This is a direct P2P message ..." never need to hit the server.

--- a/udp-echo/test-udp-puncher/test-client.cpp
+++ b/udp-echo/test-udp-puncher/test-client.cpp
@@ -1,0 +1,206 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <time.h>
+
+#define PORT 8080
+#define MAXLINE 1024
+#define REREGISTER_CLOCK 30
+
+int serverIndex = 0;
+int nameIndex = 0;
+int portIndex = 0;
+int contactIndex = 0;
+
+char name[128] = "client";
+char contact[128] = "contact";
+char serverAddress[128] = "127.0.0.1";
+int serverPort = 8080;
+
+void printUsage(char *prog)
+{
+   printf("Usage: \r\n");
+   printf("\t%s -s <server address> -p <server port> -n <my name> -c <name to contact>\n", prog);
+   printf("where:\r\n");
+   printf("\t <server address> is the STAGE MANAGER server to connect to\r\n");
+   printf("\t <server port> is the STAGE MANAGER port to connect to\r\n");
+   printf("\t <name> is a text string to send to the server\r\n");
+   printf("example:\r\n\t(alice would do this, if she is trying to reach bob)\r\n");
+   printf("\t%s -s 127.0.0.1 -p 8080 -n alice -c bob\r\n", prog);
+   printf("\t(bob would do this, if he is trying to reach alice)\r\n");
+   printf("\t%s -s 127.0.0.1 -p 8080 -n bob -c alice\r\n", prog);
+}
+
+int processArgs(int argc, char **argv)
+{
+   int i;
+
+   if (argc < 9)
+   {
+      printUsage(argv[0]);
+      return -1;
+   }
+
+   for (i = 1; i < argc; i++)
+   {
+      if (strcmp(argv[i], "-h") == 0)
+      {
+         printUsage(argv[0]);
+         return -1;
+      }
+
+      if (strcmp(argv[i], "-p") == 0)
+      {
+         i++;
+         portIndex = i;
+         serverPort = atoi(argv[i]);
+      }
+
+      if (strcmp(argv[i], "-s") == 0)
+      {
+         i++;
+         serverIndex = i;
+         strcpy(serverAddress, argv[i]);
+      }
+
+      if (strcmp(argv[i], "-n") == 0)
+      {
+         i++;
+         nameIndex = i;
+         strcpy(name, argv[i]);
+      }
+
+      if (strcmp(argv[i], "-c") == 0)
+      {
+         i++;
+         contactIndex = i;
+         strcpy(contact, argv[i]);
+      }
+   }
+
+   if (portIndex == 0 || nameIndex == 0 || serverIndex == 0 || contactIndex == 0)
+   {
+      printUsage(argv[0]);
+      return -1;
+   }
+
+   return 0;
+}
+
+void stageManagerHandler()
+{
+   int sockfd;
+   struct sockaddr_in servaddr, cliaddr, contactaddr;
+   struct timeval timeout;
+   char buffer[MAXLINE];
+   int reregister_clock = REREGISTER_CLOCK;
+
+   // Creating socket file descriptor
+   if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+   {
+      perror("socket creation failed");
+      exit(EXIT_FAILURE);
+   }
+
+   timeout.tv_sec = 1; // set the read timeout to a seconds so we can keep alive connections
+   timeout.tv_usec = 0;
+   setsockopt(sockfd, SOL_SOCKET, SO_RCVTIMEO, (struct timeval *)&timeout, sizeof(struct timeval));
+
+   memset(&servaddr, 0, sizeof(servaddr));
+   memset(&contactaddr, 0, sizeof(contactaddr));
+
+   // Filling server information
+   servaddr.sin_family = AF_INET;
+   inet_pton(AF_INET, serverAddress, &servaddr.sin_addr);
+   servaddr.sin_port = htons(serverPort);
+
+   socklen_t len;
+   int n;
+   char ipaddr[INET_ADDRSTRLEN];
+
+   while (1)
+   {
+      puts("Registering with Stage Manager.");
+      sendto(sockfd, name, strlen(name),
+             0, (const struct sockaddr *)&servaddr,
+             sizeof(servaddr));
+      puts("Retrieving incoming messages.");
+      while (1)
+      {
+         n = recvfrom(sockfd, (char *)buffer, MAXLINE,
+                      MSG_WAITALL, (struct sockaddr *)&cliaddr,
+                      &len);
+         printf(".");
+         fflush(stdout);
+         reregister_clock--;
+         if (reregister_clock <= 0)
+         {
+            reregister_clock = REREGISTER_CLOCK;
+            break;
+         }
+         if (n < 0)
+            continue; // just wait some more
+
+         buffer[n] = '\0';
+         // check who it was that just sent the message
+         inet_ntop(AF_INET, &(cliaddr.sin_addr), ipaddr, INET_ADDRSTRLEN);
+         // This is not really a solid test, but should be good enough in most cases
+         if (strcmp(ipaddr, serverAddress) == 0 && cliaddr.sin_port == servaddr.sin_port)
+         {
+            printf("Stage Manager sent us a Phonebook entry: %s", buffer);
+            char delims[8] = ",\n\r ";
+            int slotnum = atoi(strtok(buffer, delims));
+            int nslots = atoi(strtok(NULL, delims));
+            char peer_name[256];
+            strncpy(peer_name, strtok(NULL, delims), 256);
+            char peer_addr[256];
+            strncpy(peer_addr, strtok(NULL, delims), 256);
+            int peer_port = atoi(strtok(NULL, delims));
+            printf("Peer: %d/%d %s@%s:%d\n", slotnum, nslots, peer_name, peer_addr, peer_port);
+            if (strcmp(peer_name, contact) == 0)
+            {
+               // we found the contact we are looking for!
+               printf("Located %s!\n", peer_name);
+               // Filling the contact server information
+               contactaddr.sin_family = AF_INET;
+               inet_pton(AF_INET, peer_addr, &contactaddr.sin_addr);
+               contactaddr.sin_port = htons(peer_port);
+            }
+         }
+         else
+         {
+            printf("We received a peer message of len %d from %s:%d ->>\n%s\n", n, ipaddr, cliaddr.sin_port, buffer);
+         }
+         if (contactaddr.sin_port != 0)
+         {
+            // We have contact info, so keep trying to talk to them :-)
+            sleep(1); // just to slow things down a bit
+            sprintf(buffer, "This is a direct P2P message from %s to %s", name, contact);
+            sendto(sockfd, buffer, strlen(buffer),
+                   0, (const struct sockaddr *)&contactaddr,
+                   sizeof(contactaddr));
+         }
+      }
+   }
+}
+
+int main(int argc, char **argv)
+{
+   if (processArgs(argc, argv) != 0)
+   {
+      return -1;
+   }
+
+   printf("Stage Manager Server address: %s\r\n", serverAddress);
+   printf("My Name: %s\r\n", name);
+
+   stageManagerHandler();
+   // never returns
+
+   return 0;
+}

--- a/udp-echo/test-udp-puncher/test-server.cpp
+++ b/udp-echo/test-udp-puncher/test-server.cpp
@@ -1,0 +1,166 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <time.h>
+
+#define DEFAULT_PORT 8080
+#define MAXLINE 1024
+#define MAXCLIENTS 16
+#define MAXSTRING 256
+
+int port = DEFAULT_PORT;
+
+void printUsage(char *prog)
+{
+   printf("Usage: \r\n");
+   printf("\t%s [-p PORT]\r\n", prog);
+   printf("where:\r\n");
+   printf("\t PORT is the port number to listen on (default 8080) and should be reachable from the internet\r\n");
+   printf("example:\r\n");
+   printf("\t%s -p 8888\r\n", prog);
+}
+
+int processArgs(int argc, char **argv)
+{
+
+   if (argc == 1)
+      return 0;
+
+   if (argc != 3)
+   {
+      printUsage(argv[0]);
+      return -1;
+   }
+
+   if (strcmp(argv[1], "-p") != 0)
+   {
+      printUsage(argv[0]);
+      return -1;
+   }
+
+   if (argc == 3)
+   {
+      int p = atoi(argv[2]);
+      if (p > 0)
+      {
+         port = p;
+         printf("Port number set to %d\n", port);
+      }
+      else
+      {
+         printf("Malformed port number?\r\n");
+         printUsage(argv[0]);
+         return -1;
+      }
+   }
+   return 0;
+}
+
+void serverHandler()
+{
+   int sockfd;
+   char buffer[MAXLINE];
+   struct sockaddr_in servaddr, cliaddr;
+   static char names[MAXCLIENTS][MAXSTRING], addrs[MAXCLIENTS][MAXSTRING], ports[MAXCLIENTS][MAXSTRING];
+   int next_client_num = 0;
+   int num_clients = 0;
+
+   // Creating socket file descriptor
+   if ((sockfd = socket(AF_INET, SOCK_DGRAM, 0)) < 0)
+   {
+      perror("socket creation failed");
+      exit(EXIT_FAILURE);
+   }
+
+   memset(&servaddr, 0, sizeof(servaddr));
+   memset(&cliaddr, 0, sizeof(cliaddr));
+
+   // Filling server information
+   servaddr.sin_family = AF_INET; // IPv4
+   servaddr.sin_addr.s_addr = INADDR_ANY;
+   servaddr.sin_port = htons(port);
+
+   // Bind the socket with the server address
+   if (bind(sockfd, (const struct sockaddr *)&servaddr,
+            sizeof(servaddr)) < 0)
+   {
+      perror("bind failed");
+      exit(EXIT_FAILURE);
+   }
+
+   socklen_t len;
+   int n;
+
+   len = sizeof(cliaddr); //len is value/resuslt
+
+   printf("Connection Server ready to receive on port %d.\nMake sure this is reachable from the internet.\n", port);
+
+   while (1)
+   {
+      char *client_name;
+      int client_num = -1;
+
+      n = recvfrom(sockfd, (char *)buffer, MAXLINE,
+                   MSG_WAITALL, (struct sockaddr *)&cliaddr,
+                   &len);
+      buffer[n] = '\0';
+      printf("Client from %s : %d sent: %s\n", inet_ntoa(cliaddr.sin_addr), ntohs(cliaddr.sin_port), buffer);
+      client_name = strtok(buffer, "\r\n ");
+      // is this a new name?
+      for (int i = 0; i < num_clients; i++)
+      {
+         if (strcmp(names[i], client_name) == 0)
+         {
+            // found it, not a new name
+            client_num = i;
+         }
+      }
+      if (client_num < 0)
+      {
+         // new name, which slot should we give?
+         client_num = next_client_num;
+         next_client_num++;
+         if (next_client_num >= MAXCLIENTS)
+         {
+            next_client_num = 0;
+            printf("**WARNING** TOO MANY CLIENTS, STARTING TO DROP THE OLDEST ONES**\n");
+         }
+         if (num_clients < MAXCLIENTS)
+            num_clients++;
+         printf("Adding client #%d to table of clients.\n", client_num);
+      }
+      else
+      {
+         printf("Updating client #%d in table of clients.\n", client_num);
+      }
+      snprintf(names[client_num], MAXSTRING, "%s", client_name);
+      snprintf(addrs[client_num], MAXSTRING, "%s", inet_ntoa(cliaddr.sin_addr));
+      snprintf(ports[client_num], MAXSTRING, "%d", ntohs(cliaddr.sin_port));
+      // Send the current list of clients back to this client that just connected
+      for (int i = 0; i < num_clients; i++)
+      {
+         snprintf(buffer, MAXLINE, "%d,%d,%s,%s,%s\n", i, num_clients, names[i], addrs[i], ports[i]);
+         printf("%s", buffer);
+         sendto(sockfd, buffer, strlen(buffer),
+                MSG_CONFIRM, (const struct sockaddr *)&cliaddr,
+                sizeof(cliaddr));
+      }
+   }
+}
+
+int main(int argc, char **argv)
+{
+   if (processArgs(argc, argv) != 0)
+   {
+      return -1;
+   }
+
+   serverHandler();
+   // never returns
+   return 0;
+}


### PR DESCRIPTION
Hi Rob ... I am attaching the sample code for the udp-puncher. I've created a subdirectory in udp-echo called test-udp-punch along with a README.

For your testing convenience, I am running a public server at 165.227.15.53, so you don't need to run a server to test this.

In order to run this, go behind your first NAT and try this to tell the server that `alice` wants to connect to `bob`:
```
./test-client -s 165.227.15.53 -p 8080 -n alice -c bob
```
Then go behind a second NAT (or firewall or whatever) and try this (notice the slightly different command line) to tell the server that `bob` wants to connect to `alice`:
```
./test-client -s 165.227.15.53 -p 8080 -n bob -c alice
```

If all goes well, in a short while you should see direct P2P UDP messages flowing between Alice and Bob :-)

Let me know if you hit a problem ... more details in the README and in the code.
